### PR TITLE
kanidm: module improvements

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -333,7 +333,6 @@
   ./services/databases/hbase.nix
   ./services/databases/influxdb.nix
   ./services/databases/influxdb2.nix
-  ./services/databases/kanidm.nix
   ./services/databases/memcached.nix
   ./services/databases/monetdb.nix
   ./services/databases/mongodb.nix
@@ -936,6 +935,7 @@
   ./services/security/hockeypuck.nix
   ./services/security/hologram-server.nix
   ./services/security/hologram-agent.nix
+  ./services/security/kanidm.nix
   ./services/security/munge.nix
   ./services/security/nginx-sso.nix
   ./services/security/oauth2_proxy.nix

--- a/nixos/modules/services/databases/kanidm.nix
+++ b/nixos/modules/services/databases/kanidm.nix
@@ -1,112 +1,335 @@
-{ config, pkgs, lib, ... }:
+{ config, lib, options, pkgs, ... }:
 let
   cfg = config.services.kanidm;
   settingsFormat = pkgs.formats.toml { };
+  serverConfigFile = settingsFormat.generate "server.toml" cfg.serverSettings;
+  clientConfigFile = settingsFormat.generate "kanidm-config.toml" cfg.clientSettings;
+  unixConfigFile = settingsFormat.generate "kanidm-unixd.toml" cfg.unixSettings;
+
+  defaultServiceConfig = {
+    BindReadOnlyPaths = [
+      "/nix/store"
+      "-/etc/resolv.conf"
+      "-/etc/nsswitch.conf"
+      "-/etc/hosts"
+      "-/etc/localtime"
+    ];
+    CapabilityBoundingSet = "";
+    # ProtectClock= adds DeviceAllow=char-rtc r
+    DeviceAllow = "";
+    # Implies ProtectSystem=strict, which re-mounts all paths
+    #DynamicUser = true;
+    LockPersonality = true;
+    MemoryDenyWriteExecute = true;
+    NoNewPrivileges = true;
+    PrivateDevices = true;
+    PrivateMounts = true;
+    PrivateNetwork = true;
+    PrivateTmp = true;
+    PrivateUsers = true;
+    ProcSubset = "pid";
+    ProtectClock = true;
+    ProtectHome = true;
+    ProtectHostname = true;
+    # Would re-mount paths ignored by temporary root
+    #ProtectSystem = "strict";
+    ProtectControlGroups = true;
+    ProtectKernelLogs = true;
+    ProtectKernelModules = true;
+    ProtectKernelTunables = true;
+    ProtectProc = "invisible";
+    RestrictAddressFamilies = [ ];
+    RestrictNamespaces = true;
+    RestrictRealtime = true;
+    RestrictSUIDSGID = true;
+    SystemCallArchitectures = "native";
+    SystemCallFilter = [ "@system-service" "~@privileged @resources @setuid @keyring" ];
+    # Does not work well with the temporary root
+    #UMask = "0066";
+  };
+
 in
 {
+  options = {
+    services.kanidm = {
+      enable = lib.mkEnableOption "the kanidm server";
+      enablePam = lib.mkEnableOption "the pam and nsswitch integration of kanidm";
 
-  options.services.kanidm = {
-    enable = lib.mkEnableOption "kanidm service";
-
-    ensureDomainName = lib.mkOption {
-      description = ''
-        The domain_name that Kanidm manages. It must be a descendant or equal to the domain
-        specified in settings.origin. It is always set when the server starts up.
-        While in theory it could be changed later, you should carefully consider these
-        warnings:
-        <link xlink:href="https://kanidm.github.io/kanidm/administrivia.html#rename-the-domain"/>
-      '';
-      example = "example.org";
-      type = lib.types.str;
-    };
-
-    settings = lib.mkOption {
-      type = lib.types.submodule {
-
-        freeformType = settingsFormat.type;
-
-        options.bindaddress = lib.mkOption {
-          description = "Address/port combination the webserver binds to.";
-          example = "[::1]:8443";
-          type = lib.types.str;
-        };
-        options.origin = lib.mkOption {
-          description = "The origin of your kanidm instance. Must have https as protocol.";
-          example = "https://idm.example.org";
-          type = lib.types.str;
-        };
-        options.db_path = lib.mkOption {
-          description = "Path to kanidm database.";
-          default = "/var/lib/kanidm/kanidm.db";
-          type = lib.types.path;
-        };
-        options.log_level = lib.mkOption {
-          description = "Log level of the server.";
-          default = "default";
-          type = lib.types.enum [ "default" "verbose" "perfbasic" "perffull" ];
-        };
-        options.role = lib.mkOption {
-          description = "The role of this server. This affects features available and how replication may interact.";
-          default = "WriteReplica";
-          type = lib.types.enum [ "WriteReplica" "WriteReplicaNoUI" "ReadOnlyReplica" ];
-        };
-
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.kanidm;
+        description = "Which kanidm package to use.";
       };
-      default = { };
-      description = ''
-        Settings for kanidm, see
-        <link xlink:href="https://github.com/kanidm/kanidm/blob/master/examples/server.toml"/>
-        for example config.
-      '';
+
+      ensureDomainName = lib.mkOption {
+        description = ''
+          The domain_name that Kanidm manages. It must be a descendant or equal to the domain
+          specified in settings.origin. It is always set when the server starts up.
+          While in theory it could be changed later, you should carefully consider these
+          warnings:
+          <link xlink:href="https://kanidm.github.io/kanidm/administrivia.html#rename-the-domain"/>
+        '';
+        example = "example.org";
+        type = lib.types.str;
+      };
+
+      serverSettings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = settingsFormat.type;
+
+          options.bindaddress = lib.mkOption {
+            description = "Address/port combination the webserver binds to.";
+            example = "[::1]:8443";
+            type = lib.types.str;
+          };
+          options.ldapbindaddress = lib.mkOption {
+            description = "Address/port combination the emulated ldap server binds to.";
+            example = "[::1]:389";
+            default = "";
+            type = lib.types.str;
+          };
+          options.origin = lib.mkOption {
+            description = "The origin of your kanidm instance. Must have https as protocol.";
+            example = "https://idm.example.org";
+            type = lib.types.str;
+          };
+          options.db_path = lib.mkOption {
+            description = "Path to kanidm database.";
+            default = "/var/lib/kanidm/kanidm.db";
+            type = lib.types.path;
+          };
+          options.log_level = lib.mkOption {
+            description = "Log level of the server.";
+            default = "default";
+            type = lib.types.enum [ "default" "verbose" "perfbasic" "perffull" ];
+          };
+          options.role = lib.mkOption {
+            description = "The role of this server. This affects features available and how replication may interact.";
+            default = "WriteReplica";
+            type = lib.types.enum [ "WriteReplica" "WriteReplicaNoUI" "ReadOnlyReplica" ];
+          };
+        };
+        default = { };
+        description = ''
+          Settings for kanidm, see
+          <link xlink:href="https://github.com/kanidm/kanidm/blob/master/kanidm_book/src/server_configuration.md">the documentation</link>
+          and <link xlink:href="https://github.com/kanidm/kanidm/blob/master/examples/server.toml"/>
+          for the example config.
+        '';
+      };
+
+      clientSettings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = settingsFormat.type;
+
+          options.uri = lib.mkOption {
+            description = "Address of the kanidm server.";
+            example = "http://127.0.0.1:8080";
+            type = lib.types.str;
+          };
+        };
+        description = ''
+          Configure kanidm clients, needed for the PAM daemon.
+          See <link xlink:href="https://github.com/kanidm/kanidm/blob/master/kanidm_book/src/client_tools.md#kanidm-configuration">the documentation</link>
+          for possible settings.
+        '';
+      };
+
+      unixSettings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = settingsFormat.type;
+
+          options.pam_allowed_login_groups = lib.mkOption {
+            description = "kanidm group that is allowed to login in PAM";
+            example = "my_pam_group";
+            type = lib.types.str;
+          };
+        };
+        description = ''
+          Configure kanidm unix daemon.
+          See <link xlink:href="https://github.com/kanidm/kanidm/blob/master/kanidm_book/src/pam_and_nsswitch.md#the-unix-daemon">the documentation</link>
+          for possible settings.
+        '';
+      };
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf (cfg.enable || cfg.enablePam) {
+    assertions =
+      [
+        {
+          assertion = !cfg.enable || ((cfg.serverSettings.tls_chain or null) == null) || (!lib.isStorePath cfg.serverSettings.tls_chain);
+          message = ''
+            <option>services.kanidm.serverSettings.tls_chain</option> points to
+            a file in the Nix store. You should use a quoted absolute path to
+            prevent this.
+          '';
+        }
+        {
+          assertion = !cfg.enable || ((cfg.serverSettings.tls_key or null) == null) || (!lib.isStorePath cfg.serverSettings.tls_key);
+          message = ''
+            <option>services.kanidm.serverSettings.tls_key</option> points to
+            a file in the Nix store. You should use a quoted absolute path to
+            prevent this.
+          '';
+        }
+        {
+          assertion = !cfg.enablePam || options.services.kanidm.clientSettings.isDefined;
+          message = ''
+            <option>services.kanidm.clientSettings</option> needs to be configured
+            for the PAM daemon to connect to the kanidmd server.
+          '';
+        }
+        {
+          assertion = !cfg.enable || (isNull cfg.ensureDomainName
+            -> cfg.settings.role == "WriteReplica" || cfg.settings.role == "WriteReplicaNoUI");
+          message = ''
+            <option>services.kanidm.ensureDomainName</option> can only be set if this instance
+            is not a ReadOnlyReplica. Otherwise the db would inherit it from
+            the instance it follows.
+          '';
+        }
+      ];
 
-    assertions = [
-      {
-        assertion = isNull cfg.ensureDomainName
-          -> cfg.settings.role == "WriteReplica" || cfg.settings.role == "WriteReplicaNoUI";
-        message = ''
-          services.kanidm.ensureDomainName can only be set if this instance
-          is not a ReadOnlyReplica. Otherwise the db would inherit it from
-          the instance it follows.
-        '';
-      }
-    ];
+    environment.systemPackages = [ cfg.package ];
 
-    systemd.services.kanidm = {
-      description = "Kanidm server";
-      after = [ "network.target" ];
+    systemd.services.kanidm = lib.mkIf cfg.enable {
+      description = "kanidm identity management daemon";
       wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
+      after = [ "network.target" ];
+      serviceConfig = defaultServiceConfig // {
+        StateDirectory = "kanidm";
+        StateDirectoryMode = "0700";
+        ExecStart = "${cfg.package}/bin/kanidmd server -c ${serverConfigFile}";
         ExecPreStart = ''
-          ${pkgs.kanidm}/bin/kanidmd domain_name_change \
-            --config ${settingsFormat.generate "config.toml" cfg.settings} \
+          ${cfg.package}/bin/kanidmd domain_name_change \
+            -c ${serverConfigFile} \
             -n ${cfg.ensureDomainName}
         '';
-        ExecStart = ''
-          ${pkgs.kanidm}/bin/kanidmd server \
-            --config ${settingsFormat.generate "config.toml" cfg.settings}
-        '';
-        Restart = "always";
-        StateDirectory = "kanidm";
-        RuntimeDirectory = "kanidm";
-        RuntimeDirectoryMode = "0700";
         User = "kanidm";
         Group = "kanidm";
+
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
+        # Port needs to be exposed to the host network
+        PrivateNetwork = false;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        TemporaryFileSystem = "/:ro";
       };
+      environment.RUST_LOG = "info";
     };
 
-    users.users.kanidm = {
-      isSystemUser = true;
-      group = "kanidm";
-      packages = [ pkgs.kanidm ];
-    };
-    users.groups.kanidm = { };
+    systemd.services.kanidm-unixd = lib.mkIf cfg.enablePam {
+      description = "kanidm PAM daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      restartTriggers = [ unixConfigFile clientConfigFile ];
+      serviceConfig = defaultServiceConfig // {
+        CacheDirectory = "kanidm-unixd";
+        CacheDirectoryMode = "0700";
+        RuntimeDirectory = "kanidm-unixd";
+        ExecStart = "${cfg.package}/bin/kanidm_unixd";
+        User = "kanidm-unixd";
+        Group = "kanidm-unixd";
 
+        BindReadOnlyPaths = [
+          "/nix/store"
+          "-/etc/resolv.conf"
+          "-/etc/nsswitch.conf"
+          "-/etc/hosts"
+          "-/etc/localtime"
+          "-/etc/kanidm"
+          "-/etc/static/kanidm"
+        ];
+        BindPaths = [
+          # To create the socket
+          "/run/kanidm-unixd:/var/run/kanidm-unixd"
+        ];
+        # Needs to connect to kanidmd
+        PrivateNetwork = false;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        TemporaryFileSystem = "/:ro";
+      };
+      environment.RUST_LOG = "info";
+    };
+
+    systemd.services.kanidm-unixd-tasks = lib.mkIf cfg.enablePam {
+      description = "kanidm PAM home management daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "kanidm-unixd.service" ];
+      partOf = [ "kanidm-unixd.service" ];
+      restartTriggers = [ unixConfigFile clientConfigFile ];
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/kanidm_unixd_tasks";
+
+        BindReadOnlyPaths = [
+          "/nix/store"
+          "-/etc/resolv.conf"
+          "-/etc/nsswitch.conf"
+          "-/etc/hosts"
+          "-/etc/localtime"
+          "-/etc/kanidm"
+          "-/etc/static/kanidm"
+        ];
+        BindPaths = [
+          # To manage home directories
+          "/home"
+          # To connect to kanidm-unixd
+          "/run/kanidm-unixd:/var/run/kanidm-unixd"
+        ];
+        # CAP_DAC_OVERRIDE is needed to ignore ownership of unixd socket
+        CapabilityBoundingSet = [ "CAP_CHOWN" "CAP_FOWNER" "CAP_DAC_OVERRIDE" "CAP_DAC_READ_SEARCH" ];
+        IPAddressDeny = "any";
+        # Need access to users
+        PrivateUsers = false;
+        # Need access to home directories
+        ProtectHome = false;
+        RestrictAddressFamilies = [ "AF_UNIX" ];
+        TemporaryFileSystem = "/:ro";
+      };
+      environment.RUST_LOG = "info";
+    };
+
+    # These paths are hardcoded
+    environment.etc = lib.mkMerge [
+      (lib.mkIf options.services.kanidm.clientSettings.isDefined {
+        "kanidm/config".source = clientConfigFile;
+      })
+      (lib.mkIf cfg.enablePam {
+        "kanidm/unixd".source = unixConfigFile;
+      })
+    ];
+
+    system.nssModules = lib.mkIf cfg.enablePam [ cfg.package ];
+
+    system.nssDatabases.group = lib.optional cfg.enablePam "kanidm";
+    system.nssDatabases.passwd = lib.optional cfg.enablePam "kanidm";
+
+    users.groups = lib.mkMerge [
+      (lib.mkIf cfg.enable {
+        kanidm = {};
+      })
+      (lib.mkIf cfg.enablePam {
+        kanidm-unixd = {};
+      })
+    ];
+    users.users = lib.mkMerge [
+      (lib.mkIf cfg.enable {
+        kanidm = {
+          description = "kanidm server";
+          isSystemUser = true;
+          group = "kanidm";
+        };
+      })
+      (lib.mkIf cfg.enablePam {
+        kanidm-unixd = {
+          description = "kanidm PAM daemon";
+          isSystemUser = true;
+          group = "kanidm-unixd";
+        };
+      })
+    ];
   };
 
-  meta.maintainers = with lib.maintainers; [ erictapen ];
-
+  meta.maintainers = with lib.maintainers; [ erictapen Flakebi ];
 }

--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -50,107 +50,107 @@ let
 
 in
 {
-  options = {
-    services.kanidm = {
-      enable = lib.mkEnableOption "the kanidm server";
-      enablePam = lib.mkEnableOption "the pam and nsswitch integration of kanidm";
+  options.services.kanidm = {
+    enable = lib.mkEnableOption "the kanidm server";
+    enablePam = lib.mkEnableOption "the pam and nsswitch integration of kanidm";
 
-      package = lib.mkOption {
-        type = lib.types.package;
-        default = pkgs.kanidm;
-        description = "Which kanidm package to use.";
-      };
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.kanidm;
+      description = "Which kanidm package to use.";
+    };
 
-      ensureDomainName = lib.mkOption {
-        description = ''
-          The domain_name that Kanidm manages. It must be a descendant or equal to the domain
-          specified in settings.origin. It is always set when the server starts up.
-          While in theory it could be changed later, you should carefully consider these
-          warnings:
-          <link xlink:href="https://kanidm.github.io/kanidm/administrivia.html#rename-the-domain"/>
-        '';
-        example = "example.org";
-        type = lib.types.str;
-      };
+    ensureDomainName = lib.mkOption {
+      description = ''
+        The domain_name that Kanidm manages. It must be a descendant or equal to the domain
+        specified in settings.origin. It is always set when the server starts up.
+        While in theory it could be changed later, you should carefully consider these
+        warnings:
+        <link xlink:href="https://kanidm.github.io/kanidm/administrivia.html#rename-the-domain"/>
+      '';
+      example = "example.org";
+      type = lib.types.str;
+    };
 
-      serverSettings = lib.mkOption {
-        type = lib.types.submodule {
-          freeformType = settingsFormat.type;
+    serverSettings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
 
-          options.bindaddress = lib.mkOption {
+        options = {
+          bindaddress = lib.mkOption {
             description = "Address/port combination the webserver binds to.";
             example = "[::1]:8443";
             type = lib.types.str;
           };
-          options.ldapbindaddress = lib.mkOption {
+          ldapbindaddress = lib.mkOption {
             description = "Address/port combination the emulated ldap server binds to.";
             example = "[::1]:389";
             default = "";
             type = lib.types.str;
           };
-          options.origin = lib.mkOption {
+          origin = lib.mkOption {
             description = "The origin of your kanidm instance. Must have https as protocol.";
             example = "https://idm.example.org";
             type = lib.types.str;
           };
-          options.db_path = lib.mkOption {
+          db_path = lib.mkOption {
             description = "Path to kanidm database.";
             default = "/var/lib/kanidm/kanidm.db";
             type = lib.types.path;
           };
-          options.log_level = lib.mkOption {
+          log_level = lib.mkOption {
             description = "Log level of the server.";
             default = "default";
             type = lib.types.enum [ "default" "verbose" "perfbasic" "perffull" ];
           };
-          options.role = lib.mkOption {
+          role = lib.mkOption {
             description = "The role of this server. This affects features available and how replication may interact.";
             default = "WriteReplica";
             type = lib.types.enum [ "WriteReplica" "WriteReplicaNoUI" "ReadOnlyReplica" ];
           };
         };
-        default = { };
-        description = ''
-          Settings for kanidm, see
-          <link xlink:href="https://github.com/kanidm/kanidm/blob/master/kanidm_book/src/server_configuration.md">the documentation</link>
-          and <link xlink:href="https://github.com/kanidm/kanidm/blob/master/examples/server.toml"/>
-          for the example config.
-        '';
       };
+      default = { };
+      description = ''
+        Settings for kanidm, see
+        <link xlink:href="https://github.com/kanidm/kanidm/blob/master/kanidm_book/src/server_configuration.md">the documentation</link>
+        and <link xlink:href="https://github.com/kanidm/kanidm/blob/master/examples/server.toml"/>
+        for the example config.
+      '';
+    };
 
-      clientSettings = lib.mkOption {
-        type = lib.types.submodule {
-          freeformType = settingsFormat.type;
+    clientSettings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
 
-          options.uri = lib.mkOption {
-            description = "Address of the kanidm server.";
-            example = "http://127.0.0.1:8080";
-            type = lib.types.str;
-          };
+        options.uri = lib.mkOption {
+          description = "Address of the kanidm server.";
+          example = "http://127.0.0.1:8080";
+          type = lib.types.str;
         };
-        description = ''
-          Configure kanidm clients, needed for the PAM daemon.
-          See <link xlink:href="https://github.com/kanidm/kanidm/blob/master/kanidm_book/src/client_tools.md#kanidm-configuration">the documentation</link>
-          for possible settings.
-        '';
       };
+      description = ''
+        Configure kanidm clients, needed for the PAM daemon.
+        See <link xlink:href="https://github.com/kanidm/kanidm/blob/master/kanidm_book/src/client_tools.md#kanidm-configuration">the documentation</link>
+        for possible settings.
+      '';
+    };
 
-      unixSettings = lib.mkOption {
-        type = lib.types.submodule {
-          freeformType = settingsFormat.type;
+    unixSettings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
 
-          options.pam_allowed_login_groups = lib.mkOption {
-            description = "kanidm group that is allowed to login in PAM";
-            example = "my_pam_group";
-            type = lib.types.str;
-          };
+        options.pam_allowed_login_groups = lib.mkOption {
+          description = "kanidm group that is allowed to login in PAM";
+          example = "my_pam_group";
+          type = lib.types.listOf lib.types.str;
         };
-        description = ''
-          Configure kanidm unix daemon.
-          See <link xlink:href="https://github.com/kanidm/kanidm/blob/master/kanidm_book/src/pam_and_nsswitch.md#the-unix-daemon">the documentation</link>
-          for possible settings.
-        '';
       };
+      description = ''
+        Configure kanidm unix daemon.
+        See <link xlink:href="https://github.com/kanidm/kanidm/blob/master/kanidm_book/src/pam_and_nsswitch.md#the-unix-daemon">the documentation</link>
+        for possible settings.
+      '';
     };
   };
 

--- a/nixos/tests/kanidm.nix
+++ b/nixos/tests/kanidm.nix
@@ -9,14 +9,13 @@ import ./make-test-python.nix ({ pkgs, ... }:
   in
   {
     name = "kanidm";
-    meta.maintainers = with pkgs.lib.maintainers; [ erictapen ];
+    meta.maintainers = with pkgs.lib.maintainers; [ erictapen Flakebi ];
 
     nodes.server = { config, pkgs, lib, ... }: {
-
       services.kanidm = {
         enable = true;
         ensureDomainName = serverDomain;
-        settings = {
+        serverSettings = {
           domain_name = serverDomain;
           origin = "https://idm.${serverDomain}";
           bindaddress = "[::1]:8443";

--- a/pkgs/servers/kanidm/default.nix
+++ b/pkgs/servers/kanidm/default.nix
@@ -17,16 +17,13 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "kanidm";
-  # Latest version doesn't have OIDC support. This can be changed to a stable
-  # release as soon as a new version comes out.
-  version = "unstable-2021-11-21";
+  version = "1.1.0-alpha.7";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    # master from 2021-11-21
-    rev = "0f4189a57ef9fb0f048cd2cc3f5eee3d132adbd1";
-    sha256 = "sha256-+FOcRWy8YOPAl5VgUKM1x5ZQkArYP+0rwrCQxXJ4Ms0=";
+    rev = "v${version}";
+    sha256 = "C+ITINRQLJjC8sL2PKvnnHHdLQ3y5OWz0wNMDfmn2vw=";
   };
 
   postPatch =
@@ -59,7 +56,7 @@ rustPlatform.buildRustPackage rec {
     pam
   ];
 
-  cargoHash = "sha256:0diqj41wmv0gki0lmq5c24wn2yfkkp1giabn2mcxap1sfra2mi4a";
+  cargoHash = "sha256-Cm3gNm3amUsJxDPsXDsGr+lFnN+H6XzIp4UmiUIdofM=";
 
   preFixup = ''
     installShellCompletion --bash $releaseDir/build/completions/*.bash

--- a/pkgs/servers/kanidm/default.nix
+++ b/pkgs/servers/kanidm/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , formats
+, nixosTests
 , rustPlatform
 , fetchFromGitHub
 , runCommand
@@ -65,12 +66,13 @@ rustPlatform.buildRustPackage rec {
     installShellCompletion --zsh  $releaseDir/build/completions/_*
   '';
 
+  passthru.tests = { inherit (nixosTests) kanidm; };
+
   meta = with lib; {
     description = "A simple, secure and fast identity management platform";
     homepage = "https://github.com/kanidm/kanidm";
     license = licenses.mpl20;
     platforms = platforms.linux;
-    maintainers = [ maintainers.erictapen ];
+    maintainers = with maintainers; [ erictapen Flakebi ];
   };
-
 }


### PR DESCRIPTION
I updated the package because oidc support was only added last week and didn’t land in a release yet, but it seems to work flawlessly so far. (I moved up the cargoHash, so it’s closer to the other hash that needs to be updated. I can revert that change if you want.)
For the module, I started with my file and then ported all the nice things you had in yours. I didn’t know about the freeformType before, it looks like a really useful thing.

I didn’t port the PAM part yet, it would be nice if you could rebase your branch before that (there were changes upstream a few weeks ago).
Adding a test for the PAM config sounds like a good idea.

The nixos test was missing an `https://` for the origin and I added it to the package, so it can be tested with `nix-build -A kanidm.tests` and is detected by various tools.

(https://github.com/NixOS/nixpkgs/pull/143134 for reference)